### PR TITLE
Ellipsis

### DIFF
--- a/Test/TestEval.hs
+++ b/Test/TestEval.hs
@@ -154,6 +154,14 @@ spec = do
                         ,"a,b,c = f(2,3)"
                         ,"return a,b,c"
                         ]) `shouldBe` [Number 2.0, Number 3.0, Nil]
+                describe "ellipsis" $
+                    it "should eval ellipsis to a vararg value pack" $
+                        runParse (unlines [
+                             "function f(...)"
+                            ,"  return(...)"
+                            ,"end"
+                            ,"return f(1,2)"
+                            ]) `shouldBe` [Number 1.0, Number 2.0]
 
         describe "assignments" $ do
             it "should handle trivial assignments" $ do
@@ -262,6 +270,7 @@ spec = do
             it "should correctly handle for loops that shouldn't run even once" $ do
                 runParse "for x = 2,1 do return false end return true" `shouldBe` [Boolean True]
                 runParse "for x = 1,2,-1 do return false end return true" `shouldBe` [Boolean True]
+
 
 
 main = hspec spec

--- a/Test/TestEval.hs
+++ b/Test/TestEval.hs
@@ -181,7 +181,7 @@ spec = do
                             ,"  return ..."
                             ,"end"
                             ,"a,b,c,d = f(1,2,3,4)"
-                            ,"return a,b,c"
+                            ,"return a,b,c,d"
                             ]) `shouldBe` [Number 3.0, Number 4.0, Nil, Nil]
 
         describe "assignments" $ do

--- a/Test/TestEval.hs
+++ b/Test/TestEval.hs
@@ -154,7 +154,7 @@ spec = do
                         ,"a,b,c = f(2,3)"
                         ,"return a,b,c"
                         ]) `shouldBe` [Number 2.0, Number 3.0, Nil]
-                describe "ellipsis" $
+                describe "ellipsis" $ do
                     it "should eval ellipsis to a vararg value pack" $
                         runParse (unlines [
                              "function f(...)"
@@ -162,6 +162,17 @@ spec = do
                             ,"end"
                             ,"return f(1,2)"
                             ]) `shouldBe` [Number 1.0, Number 2.0]
+
+                    it "should properly scope nested ellipsis" $
+                        runParse (unlines [
+                             "function f(...)"
+                            ,"  function g(...)"
+                            ,"     return(...)"
+                            ,"  end"
+                            ,"  return g(...), g(3,4)" -- returns first of each pack
+                            ,"end"
+                            ,"return f(1,2)"
+                            ]) `shouldBe` [Number 1.0, Number 3.0]
 
         describe "assignments" $ do
             it "should handle trivial assignments" $ do

--- a/Test/TestEval.hs
+++ b/Test/TestEval.hs
@@ -135,25 +135,26 @@ spec = do
                     ]) `shouldBe` [Number 1.0, Number 2.0, Number 3.0]
 
             describe "vararg functions" $ do
-                it "no arguments to a vararg functions should result in an empty table" $
-                    runParse "function f(...) return arg[1] end; return f()" `shouldBe` [Nil]
-                it "trying to access 'arg' in a non-vararg function should produce nil" $
-                    runParse "function f() return arg end; return f()" `shouldBe` [Nil]
-                it "just varargs" $ do
-                    runParse (unlines [
-                         "function f(...)"
-                        ,"  return arg[1], arg[2], arg[3]"
-                        ,"end"
-                        ,"return f(1,2)"
-                        ]) `shouldBe` [Number 1.0, Number 2.0, Nil]
-                it "varargs should play nice with normal parameters" $
-                    runParse (unlines [
-                         "function f(x, ...)"
-                        ,"  return x, arg[1], arg[2]"
-                        ,"end"
-                        ,"a,b,c = f(2,3)"
-                        ,"return a,b,c"
-                        ]) `shouldBe` [Number 2.0, Number 3.0, Nil]
+                describe "arg" $ do
+                    it "no arguments to a vararg functions should result in an empty table" $
+                        runParse "function f(...) return arg[1] end; return f()" `shouldBe` [Nil]
+                    it "trying to access 'arg' in a non-vararg function should produce nil" $
+                        runParse "function f() return arg end; return f()" `shouldBe` [Nil]
+                    it "just varargs" $ do
+                        runParse (unlines [
+                             "function f(...)"
+                            ,"  return arg[1], arg[2], arg[3]"
+                            ,"end"
+                            ,"return f(1,2)"
+                            ]) `shouldBe` [Number 1.0, Number 2.0, Nil]
+                    it "varargs should play nice with normal parameters" $
+                        runParse (unlines [
+                             "function f(x, ...)"
+                            ,"  return x, arg[1], arg[2]"
+                            ,"end"
+                            ,"a,b,c = f(2,3)"
+                            ,"return a,b,c"
+                            ]) `shouldBe` [Number 2.0, Number 3.0, Nil]
                 describe "ellipsis" $ do
                     it "should eval ellipsis to a vararg value pack" $
                         runParse (unlines [
@@ -173,6 +174,15 @@ spec = do
                             ,"end"
                             ,"return f(1,2)"
                             ]) `shouldBe` [Number 1.0, Number 3.0]
+
+                    it "should properly eval ellipsis together with normal parameters" $
+                        runParse (unlines [
+                             "function f(x, y, ...)"
+                            ,"  return ..."
+                            ,"end"
+                            ,"a,b,c,d = f(1,2,3,4)"
+                            ,"return a,b,c"
+                            ]) `shouldBe` [Number 3.0, Number 4.0, Nil, Nil]
 
         describe "assignments" $ do
             it "should handle trivial assignments" $ do

--- a/Turnip.cabal
+++ b/Turnip.cabal
@@ -10,7 +10,7 @@ name:                Turnip
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.3.0.0
+version:             0.3.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            Pure Lua VM for Haskell.

--- a/src/Turnip/Eval/Closure.hs
+++ b/src/Turnip/Eval/Closure.hs
@@ -35,7 +35,7 @@ closureLookupEllipsis = getClosure >>= closureLookupEllipsisFrom
 closureLookupFrom :: Value -> Closure -> LuaM Value
 -- descend recursively with lookups, picking the closest name first
 closureLookupFrom v (top:cls) = do
-    topCls <- getTableData (fst top)
+    topCls <- getTableData (closureTableRef top)
     case Map.lookup v topCls of
         Just val -> return val
         Nothing -> closureLookupFrom v cls
@@ -47,13 +47,13 @@ closureLookupFrom v _ = do
 
 closureLookupEllipsisFrom :: Closure -> LuaM (Maybe [Value])
 closureLookupEllipsisFrom (top:cls) = do
-    case (snd top) of
+    case closureVarargs top of
         Just val -> return $ Just val
         Nothing -> closureLookupEllipsisFrom cls
 closureLookupEllipsisFrom [] = return Nothing
 
 -- |Executes the code block one level deeper.
-closurePush :: forall m a. Monad m => (TableRef, Maybe [Value]) -> LuaMT m a -> LuaMT m a
+closurePush :: forall m a. Monad m => ClosureLevel -> LuaMT m a -> LuaMT m a
 closurePush t (LuaMT a) = LuaMT $ mapExceptT (withRWST (\cls s -> (t:cls, s))) a
 
 -- this is a simple helper that picks either top level closure or global table
@@ -68,9 +68,9 @@ assignmentTarget name = do
 assignmentTargetHelper :: Closure -> AST.Name -> LuaM TableRef
 assignmentTargetHelper [] _ = getGlobalTableRef
 assignmentTargetHelper (headCls:restCls) name = do
-    t <- getTableData $ fst headCls
+    t <- getTableData $ closureTableRef headCls
     case Map.lookup (Str name) t of
         -- if the name appears in the closure, we assign to this one
-        (Just _) -> return $ fst headCls
+        (Just _) -> return $ closureTableRef headCls
         -- otherwise we try going down the stack
         Nothing -> assignmentTargetHelper restCls name

--- a/src/Turnip/Eval/Closure.hs
+++ b/src/Turnip/Eval/Closure.hs
@@ -5,6 +5,7 @@
 module Turnip.Eval.Closure 
     (getClosure
     ,closureLookup
+    ,closureLookupEllipsis
     ,closurePush
     ,assignmentTarget
     )
@@ -28,10 +29,13 @@ getClosure = LuaMT . lift $ ask
 closureLookup :: Value -> LuaM Value
 closureLookup v = getClosure >>= closureLookupFrom v
 
+closureLookupEllipsis :: LuaM (Maybe [Value])
+closureLookupEllipsis = getClosure >>= closureLookupEllipsisFrom
+
 closureLookupFrom :: Value -> Closure -> LuaM Value
 -- descend recursively with lookups, picking the closest name first
-closureLookupFrom v (topRef:cls) = do
-    topCls <- getTableData topRef
+closureLookupFrom v (top:cls) = do
+    topCls <- getTableData (fst top)
     case Map.lookup v topCls of
         Just val -> return val
         Nothing -> closureLookupFrom v cls
@@ -41,8 +45,15 @@ closureLookupFrom v _ = do
     let mVal = Map.lookup v _G
     return $ extractVal mVal
 
+closureLookupEllipsisFrom :: Closure -> LuaM (Maybe [Value])
+closureLookupEllipsisFrom (top:cls) = do
+    case (snd top) of
+        Just val -> return $ Just val
+        Nothing -> closureLookupEllipsisFrom cls
+closureLookupEllipsisFrom [] = return Nothing
+
 -- |Executes the code block one level deeper.
-closurePush :: forall m a. Monad m => TableRef -> LuaMT m a -> LuaMT m a
+closurePush :: forall m a. Monad m => (TableRef, Maybe [Value]) -> LuaMT m a -> LuaMT m a
 closurePush t (LuaMT a) = LuaMT $ mapExceptT (withRWST (\cls s -> (t:cls, s))) a
 
 -- this is a simple helper that picks either top level closure or global table
@@ -57,9 +68,9 @@ assignmentTarget name = do
 assignmentTargetHelper :: Closure -> AST.Name -> LuaM TableRef
 assignmentTargetHelper [] _ = getGlobalTableRef
 assignmentTargetHelper (headCls:restCls) name = do
-    t <- getTableData headCls
+    t <- getTableData $ fst headCls
     case Map.lookup (Str name) t of
         -- if the name appears in the closure, we assign to this one
-        (Just _) -> return headCls
+        (Just _) -> return $ fst headCls
         -- otherwise we try going down the stack
         Nothing -> assignmentTargetHelper restCls name

--- a/src/Turnip/Eval/Eval.hs
+++ b/src/Turnip/Eval/Eval.hs
@@ -78,8 +78,8 @@ eval (AST.Bool b) = return [Boolean b]
 eval AST.Nil = return [Nil]
 
 -- In order to eval ellipsis, the closure needs to differentiate between
--- outer local variables and parameters. It's basically the contents of "args".
--- Perhaps it could just be a hidden args reference?
+-- outer local variables and parameters. It's basically the same as args, but
+-- not packed in a table.
 eval AST.Ellipsis = do
     e <- closureLookupEllipsis
     case e of

--- a/src/Turnip/Eval/Types.hs
+++ b/src/Turnip/Eval/Types.hs
@@ -50,7 +50,9 @@ type TableData = Map.Map Value Value
 type NativeFunction = [Value] -> LuaM [Value]
 
 -- This is a stack of tables forming a stack of nested closures
-type Closure = [(TableRef, Maybe [Value])]
+
+data ClosureLevel = ClosureLevel { closureTableRef :: TableRef, closureVarargs :: Maybe [Value] }
+type Closure = [ClosureLevel]
 
 data FunctionData = FunctionData { closure :: Closure, block :: AST.Block, paramNames :: [String], varargs :: Bool }
                   | BuiltinFunction { fn :: NativeFunction }

--- a/src/Turnip/Eval/Types.hs
+++ b/src/Turnip/Eval/Types.hs
@@ -50,7 +50,7 @@ type TableData = Map.Map Value Value
 type NativeFunction = [Value] -> LuaM [Value]
 
 -- This is a stack of tables forming a stack of nested closures
-type Closure = [TableRef]
+type Closure = [(TableRef, Maybe [Value])]
 
 data FunctionData = FunctionData { closure :: Closure, block :: AST.Block, paramNames :: [String], varargs :: Bool }
                   | BuiltinFunction { fn :: NativeFunction }


### PR DESCRIPTION
There are two problems to fix here before this gets merged:

* The closure data type isn't trivial anymore and should be named explicitly
* The double storage of `arg` and `...` needs to be addressed somehow. Lua solves that by effectively not allowing both at the same time; old versions have `arg`, new ones have `...`. This holds true except for this one transitional compatibility argument which Turnip doesn't need to support, so a fix could well be to simply disable either one for a given VM. This might imply adding VM parametrization first, though; perhaps on another branch beforehand?